### PR TITLE
Fix video grid layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -333,7 +333,7 @@ function App() {
         <h1 className="text-4xl md:text-6xl font-bold text-yellow-300">Namaa <span className="text-yellow-500">نَمَاء</span></h1>
       </header>
       <main className="flex-1 space-y-12 px-4">
-        <section className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+        <section className="grid grid-cols-3 gap-4">
           {[1,2,3].map((idx) => (
             <div
               key={idx}


### PR DESCRIPTION
## Summary
- keep the video section in 3 columns on all screen sizes

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6852a5fee97083238f417c185dbd773a