### PR TITLE
Replace flicker effect with gradient shift

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -280,7 +280,7 @@ function App() {
   };
 
   return (
-    <div className="min-h-screen flex flex-col bg-gradient-to-br from-emerald-900 via-emerald-700 to-green-600 text-white font-sans flicker-bg">
+    <div className="min-h-screen flex flex-col text-white font-sans gradient-shift">
       {showModal && (
         <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50">
           <div className="bg-white text-emerald-900 rounded-lg p-4 max-w-xl w-full">

--- a/src/index.css
+++ b/src/index.css
@@ -2,13 +2,26 @@
 @tailwind components;
 @tailwind utilities;
 
-@keyframes flicker-bg {
-  0%,100% { background: linear-gradient(to bottom right, #064e3b, #065f46, #047857); }
-  33% { background: linear-gradient(to bottom right, #065f46, #047857, #059669); }
-  66% { background: linear-gradient(to bottom right, #047857, #059669, #10b981); }
+@keyframes gradient-shift {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
 }
 
-.flicker-bg {
-  animation: flicker-bg 2s linear infinite;
+.gradient-shift {
+  background: linear-gradient(45deg,
+      #064e3b,
+      #16a34a,
+      #eab308,
+      #ef4444,
+      #3b82f6);
+  background-size: 300% 300%;
+  animation: gradient-shift 12s ease-in-out infinite;
 }
 


### PR DESCRIPTION
## Summary
- remove flickering background animation
- add a smooth gradient shift animation
- apply the new animation to the main container
- increase color contrast and tweak animation timing for a more dynamic shift

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6852abf7f49883239591e81f45af5938