### PR TITLE
Add success page and redirect form submissions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -473,7 +473,13 @@ function App() {
           <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 overflow-y-auto p-4">
             <div className="bg-white text-emerald-900 rounded-lg p-4 max-w-lg w-full space-y-4 max-h-screen overflow-y-auto shadow-xl transition-all">
               <h2 className="text-xl font-semibold text-center">BA Questionnaire Part A</h2>
-              <form className="space-y-4" onSubmit={(e) => e.preventDefault()}>
+              <form
+                className="space-y-4"
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  window.location.href = '/success.html';
+                }}
+              >
                 <fieldset className="space-y-2">
                   <legend className="font-semibold">Ethnically What Are You*</legend>
                   {['Somali Somali','Arab','Swahili','Ethiopian Somali/Oromo','Ethiopian','Kenyan Somali','Tanzanian Somali'].map((opt) => (
@@ -631,7 +637,13 @@ function App() {
               <h2 className="text-2xl font-semibold text-center mb-4 text-yellow-300">
                 CYBERSECURITY EXPERT SCREENING QUESTIONNAIRE
               </h2>
-              <form className="space-y-6" onSubmit={(e) => e.preventDefault()}>
+              <form
+                className="space-y-6"
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  window.location.href = '/success.html';
+                }}
+              >
                 {questions.map((q, idx) => (
                   <fieldset key={idx} className="space-y-2">
                     <legend className="font-semibold">{q.q}</legend>
@@ -662,7 +674,13 @@ function App() {
               <h2 className="text-2xl font-semibold text-center mb-4 text-yellow-300">
                 FULLSTACK ENGINEER SCREENING QUESTIONNAIRE
               </h2>
-              <form className="space-y-6" onSubmit={(e) => e.preventDefault()}>
+              <form
+                className="space-y-6"
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  window.location.href = '/success.html';
+                }}
+              >
                 {fullstackQuestions.map((q, idx) => (
                   <fieldset key={idx} className="space-y-2">
                     <legend className="font-semibold">{q.q}</legend>

--- a/success.html
+++ b/success.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Application Submitted</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+    <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>
+  </head>
+  <body class="bg-emerald-900 text-white font-inter flex items-center justify-center min-h-screen">
+    <div class="text-center space-y-4">
+      <h1 class="text-3xl font-bold text-yellow-300">Application Successful</h1>
+      <p class="text-lg">Thank you for applying. Please await communication from our onboarding team if selected.</p>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a new `success.html` confirmation page
- redirect all form submissions to the success page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e5718f7488323942e7b4c13ed14be